### PR TITLE
Use KERNELDIR instead of uname -r

### DIFF
--- a/src/4.18.0-513/Makefile
+++ b/src/4.18.0-513/Makefile
@@ -8,9 +8,9 @@ fuse-y := dev.o dir.o file.o inode.o control.o xattr.o acl.o readdir.o
 fuse-$(CONFIG_FUSE_DAX) += dax.o
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
 
 .PHONY: clean


### PR DESCRIPTION
The build.sh passes the KERNELDIR to the underlying make file, but that one doesn't use it and instead points to `uname -r`.